### PR TITLE
Introduce a bug when creating a teacher object

### DIFF
--- a/teacher.rb
+++ b/teacher.rb
@@ -1,6 +1,6 @@
 require_relative 'person'
 
-class Teacher < Person
+class Teacher
   def initialize(specialization, age, name)
     super(age, name)
     @specialization = specialization


### PR DESCRIPTION
At this juncture of development, I modified the well-working code to throw an error when someone tries to create a teacher object from the terminal.